### PR TITLE
Version regex update

### DIFF
--- a/tomcat.py
+++ b/tomcat.py
@@ -223,7 +223,7 @@ class Tomcat(object):
 	def get_version(self):
 		hdrs, data = self.get_error_page()
 		for d in data:
-			s = re.findall('(Apache Tomcat/[0-9\.]+) ', d.data)
+			s = re.findall('(Apache Tomcat/[0-9.]+)', d.data)
 			if len(s) > 0:
 				return s[0]
 


### PR DESCRIPTION
Removing extraneous \ from pattern (. does not need escaping in a character class) and trimming the space so that this works on a 9.0.29 which responds with:
```
<h3>Apache Tomcat/9.0.29</h3>
```